### PR TITLE
Restore any-method handling in findAll

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ router.remove('GET', '/posts/:id');
 - `Router({bool caseSensitive = false, Cache<T>? cache})`
 - `void add(String path, T data, {String? method})`
 - `RouteMatch<T>? find(String path, {String? method})`
-- `List<RouteMatch<T>> findAll(String path, {String? method})`
+- `List<RouteMatch<T>> findAll(String path, {String? method, bool includeAny = false})`
 - `bool remove(String method, String path)`
 
 ### `RouteMatch`
@@ -155,7 +155,7 @@ print(router.find('/users/1', method: 'GET')?.data);  // get
 print(router.find('/users/1', method: 'POST')?.data); // any
 ```
 
-`findAll` returns only the selected method bucket:
+`findAll` prefers exact method matches and falls back to method-agnostic matches:
 
 ```dart
 final router = Router<String>();
@@ -164,6 +164,19 @@ router.add('/api/:id', 'get', method: 'GET');
 
 print(router.findAll('/api/1', method: 'GET').map((m) => m.data));
 // (get)
+print(router.findAll('/api/1', method: 'POST').map((m) => m.data));
+// (any)
+```
+
+Set `includeAny: true` to include method-agnostic matches before exact matches:
+
+```dart
+final router = Router<String>();
+router.add('/api/:id', 'any');
+router.add('/api/:id', 'get', method: 'GET');
+
+print(router.findAll('/api/1', method: 'GET', includeAny: true).map((m) => m.data));
+// (any, get)
 ```
 
 ## Cache

--- a/lib/src/operations.dart
+++ b/lib/src/operations.dart
@@ -190,7 +190,8 @@ List<RouteMatch<T>> findAllRoutes<T>(RouterNode<T> root, bool caseSensitive, Str
 
 // dart format off
 List<RouteData<T>> _resolveMatchedRoutes<T>(bool includeAny, String method, Map<String, List<RouteData<T>>> methods) {// dart format on
-  return includeAny ? [...?methods[''], ...?methods[method]] : methods[method] ?? methods[''] ?? const [];
+  if (includeAny) return [...?methods[''], ...?methods[method]];
+  return methods[method] ?? methods[''] ?? const [];
 }
 
 // dart format off

--- a/lib/src/operations.dart
+++ b/lib/src/operations.dart
@@ -190,7 +190,9 @@ List<RouteMatch<T>> findAllRoutes<T>(RouterNode<T> root, bool caseSensitive, Str
 
 // dart format off
 List<RouteData<T>> _resolveMatchedRoutes<T>(bool includeAny, String method, Map<String, List<RouteData<T>>> methods) {// dart format on
-  if (includeAny) return [...?methods[''], ...?methods[method]];
+  if (includeAny && method.isNotEmpty) {
+    return [...?methods[''], ...?methods[method]];
+  }
   return methods[method] ?? methods[''] ?? const [];
 }
 

--- a/lib/src/operations.dart
+++ b/lib/src/operations.dart
@@ -190,7 +190,7 @@ List<RouteMatch<T>> findAllRoutes<T>(RouterNode<T> root, bool caseSensitive, Str
 
 // dart format off
 List<RouteData<T>> _resolveMatchedRoutes<T>(bool includeAny, String method, Map<String, List<RouteData<T>>> methods) {// dart format on
-  return [...?methods[method], if (includeAny) ...?methods['']];
+  return includeAny ? [...?methods[''], ...?methods[method]] : methods[method] ?? methods[''] ?? const [];
 }
 
 // dart format off

--- a/lib/src/operations.dart
+++ b/lib/src/operations.dart
@@ -181,36 +181,36 @@ List<RouteData<T>>? _lookupTree<T>(RouterNode<T> node, String method, List<Strin
 }
 
 // dart format off
-List<RouteMatch<T>> findAllRoutes<T>(RouterNode<T> root, bool caseSensitive, String method, String path) {// dart format on
+List<RouteMatch<T>> findAllRoutes<T>(RouterNode<T> root, bool caseSensitive, String method, String path, bool includeAny) {// dart format on
   final segments = splitPath(path);
   final matches = <RouteData<T>>[];
-  _findAll(root, method, segments, 0, matches, caseSensitive);
+  _findAll(root, method, segments, 0, matches, caseSensitive, includeAny);
   return matches.map((m) => m.materialize(segments)).toList();
 }
 
 // dart format off
-void _findAll<T>(RouterNode<T> node, String method, List<String> segments, int index, List<RouteData<T>> matches, bool caseSensitive) {// dart format on
+List<RouteData<T>> _resolveMatchedRoutes<T>(bool includeAny, String method, Map<String, List<RouteData<T>>> methods) {// dart format on
+  return [...?methods[method], if (includeAny) ...?methods['']];
+}
+
+// dart format off
+void _findAll<T>(RouterNode<T> node, String method, List<String> segments, int index, List<RouteData<T>> matches, bool caseSensitive, bool includeAny) {// dart format on
   // 1. Wildcard
   if (node.wildcard?.methods != null) {
-    final match =
-        node.wildcard!.methods![method] ?? node.wildcard!.methods![''];
-    if (match != null) matches.addAll(match);
+    // dart format off
+    final match = _resolveMatchedRoutes(includeAny, method, node.wildcard!.methods!); // dart format on
+    if (match.isNotEmpty) matches.addAll(match);
   }
 
   // 2. Param
   if (node.param != null) {
     if (index < segments.length) {
-      _findAll(
-        node.param!,
-        method,
-        segments,
-        index + 1,
-        matches,
-        caseSensitive,
-      );
+      // dart format off
+      _findAll(node.param!, method, segments, index + 1, matches, caseSensitive, includeAny); // dart format on
     } else if (node.param!.methods != null) {
-      final match = node.param!.methods![method] ?? node.param!.methods![''];
-      if (match != null && match.first.paramsMap?.last.optional == true) {
+      // dart format off
+      final match = _resolveMatchedRoutes(includeAny, method, node.param!.methods!); // dart format on
+      if (match.isNotEmpty && match.first.paramsMap?.last.optional == true) {
         matches.addAll(match);
       }
     }
@@ -222,21 +222,16 @@ void _findAll<T>(RouterNode<T> node, String method, List<String> segments, int i
         ? segments[index]
         : segments[index].toLowerCase();
     if (node.statics?[segment] case final staticChild?) {
-      _findAll(
-        staticChild,
-        method,
-        segments,
-        index + 1,
-        matches,
-        caseSensitive,
-      );
+      // dart format off
+      _findAll(staticChild, method, segments, index + 1, matches, caseSensitive, includeAny); // dart format on
     }
   }
 
   // 4. End of path
   if (index == segments.length && node.methods != null) {
-    final match = node.methods![method] ?? node.methods![''];
-    if (match != null) matches.addAll(match);
+    // dart format off
+    final match = _resolveMatchedRoutes(includeAny, method, node.methods!); // dart format on
+    if (match.isNotEmpty) matches.addAll(match);
   }
 }
 

--- a/lib/src/router.dart
+++ b/lib/src/router.dart
@@ -39,8 +39,9 @@ class Router<T> {
   }
 
   /// Returns all matches for [path] in broad-to-specific order.
-  List<RouteMatch<T>> findAll(String path, {String? method}) =>
-      findAllRoutes(_root, caseSensitive, _m(method), normalizePath(path));
+  // dart format off
+  List<RouteMatch<T>> findAll(String path, {String? method, bool includeAny = false}) =>
+      findAllRoutes(_root, caseSensitive, _m(method), normalizePath(path), includeAny); // dart format on
 
   /// Removes all routes stored under the exact method and path pattern.
   bool remove(String method, String path) {

--- a/test/router_test.dart
+++ b/test/router_test.dart
@@ -269,6 +269,15 @@ void main() {
         ['any'],
       );
     });
+
+    test('findAll does not duplicate any-method matches without a method', () {
+      final router = Router<String>();
+      router.add('/api/:id', 'any');
+
+      expect(router.findAll('/api/1', includeAny: true).map((m) => m.data), [
+        'any',
+      ]);
+    });
   });
 
   group('match priority', () {

--- a/test/router_test.dart
+++ b/test/router_test.dart
@@ -238,7 +238,7 @@ void main() {
       expect(router.find('/ping', method: 'GET')?.data, 'pong');
     });
 
-    test('findAll returns the selected method bucket only', () {
+    test('findAll prefers exact method and falls back to any-method', () {
       final router = Router<String>();
       router.add('/api/:id', 'any');
       router.add('/api/:id', 'get', method: 'GET');
@@ -249,6 +249,25 @@ void main() {
       expect(router.findAll('/api/1', method: 'POST').map((m) => m.data), [
         'any',
       ]);
+    });
+
+    test('findAll can include any-method matches before exact matches', () {
+      final router = Router<String>();
+      router.add('/api/:id', 'any');
+      router.add('/api/:id', 'get', method: 'GET');
+
+      expect(
+        router
+            .findAll('/api/1', method: 'GET', includeAny: true)
+            .map((m) => m.data),
+        ['any', 'get'],
+      );
+      expect(
+        router
+            .findAll('/api/1', method: 'POST', includeAny: true)
+            .map((m) => m.data),
+        ['any'],
+      );
     });
   });
 


### PR DESCRIPTION
Resolves #25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional includeAny flag to route lookup for more control; exact method matches are preferred, with method-agnostic results used as a fallback. When includeAny is true, method-agnostic matches are included (and appear before exact matches).

* **Documentation**
  * Updated examples to demonstrate fallback behavior and includeAny usage.

* **Tests**
  * Expanded tests to cover new matching semantics, ordering, and duplication prevention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->